### PR TITLE
[WIP] Enable use of docker build cache

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - master
 # https://github.com/elgohr/Publish-Docker-Github-Action#cache
-#  schedule:
-#    - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
+  schedule:
+    - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
 
 env:
   DOCKER_ORG: pangeodev
@@ -45,7 +45,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         workdir: ${{ matrix.IMAGE }}
         tags: "master, ${{env.DOCKER_TAG}}"
-#        cache: ${{ github.event_name != 'schedule' }}
+        cache: ${{ github.event_name != 'schedule' }}
     # NOTE: could save this as a build artifact or put on website
     - name: Export Full Conda Environment
       run: |


### PR DESCRIPTION
Unfortunately the current configuration doesn't make use of the `--from-cache` build option with Docker. Prior to each build, auxiliary files are copied over from the base-notebook folder:
`rsync -a -v --ignore-existing base-image/* pangeo-image/`

So even if the files are unchanged, the timestamp and metadata is different and as a result the cache is invalid from this early copy statement and all subsequent Docker commands:
https://github.com/pangeo-data/pangeo-stacks-dev/blob/5c3ae830ccb33dba3ee08dc07cc5b0504ec02fdb/base-image/Dockerfile#L18-L19

A solution would be to keep the single Dockerfile in the root of the repository but force every image folder in the repo to have its own auxiliary files (even if they are duplicates of ones in the base-image). As far as I know symbolic links don't work.
