### PR TITLE
add weekly staging build github action

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,0 +1,39 @@
+# Add date to weekly-build.log, triggering staging build once a week
+name: WeeklyBuild
+on:
+# https://github.com/elgohr/Publish-Docker-Github-Action#cache
+  schedule:
+#    - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
+    - cron:  '*/15 * * * *' # Every 15 minutes for testing
+
+env:
+  DOCKER_ORG: pangeodev
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Set Job Environment Variables
+      run: |
+        CALVER="$( date -u '+%Y.%m.%d' )"
+        echo "::set-env name=CALVER::${CALVER}"
+
+    - name: Update Weekly Build Log
+      run: |
+        echo $CALVER >> weekly-build.log
+
+    - name: Commit files
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Trigger weekly build: $CALVER" -a
+
+    - name: Push changes
+      uses: ad-m/github-push-action@v0.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ coverage.xml
 *.pot
 
 # Django stuff:
-*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/weekly-build.log
+++ b/weekly-build.log
@@ -1,0 +1,2 @@
+# List of weekly builds
+2020.02.25


### PR DESCRIPTION
This adds a cronjob workflow to trigger a new staging build once per week by adding the date to `week-build.log` 

```
# List of weekly builds
2020.02.25
```