### PR TITLE
use only conda-forge channel

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -85,12 +85,14 @@ RUN export PATH=${CONDA_DIR}/bin:$PATH \
 ONBUILD USER ${NB_USER}
 
 # Create "pangeo" environment from environment.yml
-# get pangeodask version from environment.yml and pin
+# Get pangeodask version from environment.yml
+# NOTE: not sure if we need to pin pangeo-dask and pangeo-notebook images 
 ONBUILD RUN [ -d binder ] && cd binder \
         ; if test -f "environment.yml" ; then \
         export PATH=${CONDA_DIR}/bin:$PATH \
         && conda env create -f environment.yml \
-        && grep pangeodask environment.yml | cut -d'-' -f2 > ${CONDA_DIR}/envs/pangeo/conda-meta/pinned \
+        && grep pangeo-dask environment.yml | awk '{print $NF}' > ${CONDA_DIR}/envs/pangeo/conda-meta/pinned \
+        && grep pangeo-notebook environment.yml | awk '{print $NF}' > ${CONDA_DIR}/envs/pangeo/conda-meta/pinned \
         && echo "conda activate pangeo" >> ${CONDA_DIR}/etc/profile.d/conda.sh \
         && conda clean -afy \
         && find ${CONDA_DIR} -follow -type f -name '*.a' -delete \

--- a/base-image/condarc
+++ b/base-image/condarc
@@ -1,7 +1,6 @@
 channels:
   - conda-forge
   - defaults
-  - pangeo
 channel_priority: strict
 show_channel_urls: true
 # NOTE: only works for `conda create -f`, not `conda env create -f`!

--- a/base-image/dask_config.yml
+++ b/base-image/dask_config.yml
@@ -31,7 +31,7 @@ kubernetes:
       serviceAccount: daskkubernetes
       restartPolicy: Never
       containers:
-        - name: dask-${JUPYTERHUB_USER}
+        - name: dask-worker
           image: ${JUPYTER_IMAGE_SPEC}
           args:
             - dask-worker

--- a/base-notebook/environment.yml
+++ b/base-notebook/environment.yml
@@ -1,7 +1,6 @@
 name: pangeo
 channels:
   - conda-forge
-  - pangeo
 dependencies:
   - python=3.7
   - pangeo-notebook=0.0.2

--- a/base-worker/environment.yml
+++ b/base-worker/environment.yml
@@ -1,7 +1,6 @@
 name: pangeo
 channels:
   - conda-forge
-  - pangeo
 dependencies:
   - python=3.7
   - pangeo-dask=0.0.2

--- a/pangeo-notebook/environment.yml
+++ b/pangeo-notebook/environment.yml
@@ -1,7 +1,6 @@
 name: pangeo
 channels:
   - conda-forge
-  - pangeo
 dependencies:
   - python=3.7
   - pangeo-notebook=0.0.2
@@ -22,9 +21,11 @@ dependencies:
   - intake-stac
   - intake-xarray
   - ipyleaflet
+  - ipywidgets
   - jupyter-panel-proxy
   - lz4
   - matplotlib-base
+  - nomkl
   - numpy
   - pandas
   - panel

--- a/pangeo-worker/environment.yml
+++ b/pangeo-worker/environment.yml
@@ -1,7 +1,6 @@
 name: pangeo
 channels:
   - conda-forge
-  - pangeo
 dependencies:
   - python=3.7
   - pangeo-dask=0.0.2


### PR DESCRIPTION
now that metapackages are on conda-forge (https://github.com/pangeo-data/conda-metapackages/issues/1), we can use only that channel for conda config and environment.yml files