### PR TITLE
try chatops for condalock

### DIFF
--- a/.github/workflows/ChatOps.yml
+++ b/.github/workflows/ChatOps.yml
@@ -1,0 +1,17 @@
+# https://github.com/peter-evans/slash-command-dispatch
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v1
+        with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          permission: none
+          commands: condalock

--- a/.github/workflows/CondaLock.yml
+++ b/.github/workflows/CondaLock.yml
@@ -1,0 +1,53 @@
+# Slash Command for running conda-lock on PRs
+# https://github.com/peter-evans/slash-command-dispatch/pull/11
+name: CondaLock
+
+on:
+  repository_dispatch:
+    types: [condalock-command]
+jobs:
+  autopep8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      - name: Setup Conda Environment
+        uses: goanpeca/setup-miniconda@v1
+        with:
+           environment-file: environment-condalock.yml
+           activate-environment: condalock
+           miniconda-version: 4.7.12
+           auto-update-conda: true
+
+      # For now run in all 3 notebook subfolders
+      - name: Run Condalock
+        run: |
+          CONDARC=base-image/condarc.yml conda-lock -f environment.yml -p linux-64
+          mv conda-linux-64.lock base-notebook/
+
+          CONDARC=base-image/condarc.yml conda-lock -f environment.yml -p linux-64
+          mv conda-linux-64.lock pangeo-notebook
+
+          CONDARC=ml-notebook/condarc.yml conda-lock -f environment.yml -p linux-64
+          mv conda-linux-64.lock ml-notebook
+
+      # Commit the change to the PR branch
+      - name: Commit to the PR branch
+        run: |
+          git config --global user.name 'actions-bot'
+          git config --global user.email '58130806+actions-bot@users.noreply.github.com'
+          git commit -am "[condalock-command] fixes"
+          git push
+
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -1,5 +1,5 @@
 # Check for new versions of pangeo-notebook metapackage on Conda Forge
-name: WhatCondaForge
+name: WatchCondaForge
 
 on:
   schedule:
@@ -11,19 +11,23 @@ jobs:
     if: github.repository == 'pangeo-data/pangeo-stacks-dev'
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
       - name: Get latest pangeo-notebook version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:
           org: "conda-forge"
           package: "pangeo-notebook"
+
       - name: Find and Replace Base
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
           include: ".*notebook/environment.yml"
           find: "pangeo-notebook=.* "
           replace: "pangeo-notebook=${{ steps.latest_version.outputs.version }} "
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
This addresses some pieces of https://github.com/pangeo-data/pangeo-stacks-dev/issues/27. In particular it will enable generating lockfiles from PRs using "ChatOps" (https://github.com/peter-evans/slash-command-dispatch). 

So in theory someone edits environment.yml in there fork and creates a PR. Then in a PR comment writes:

/condalock

Then a bot will run conda-lock and add the lockfiles for each image into the PR. I'll probably follow up with some direct commits to test this out or additional PRs.