### PR TITLE
automatically run condalock workflow for watchcondaforge action

### DIFF
--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -37,6 +37,7 @@ jobs:
           title: "Update pangeo-notebook metapackage version to ${{ steps.latest_version.outputs.version }}"
           reviewers: "scottyhq"
           branch: "upgrade-pangeo-metapackage-version"
+          branch-suffix: timestamp
           body: |
             /condalock
 

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -38,6 +38,10 @@ jobs:
           reviewers: "scottyhq"
           branch: "upgrade-pangeo-metapackage-version"
           body: |
+            /condalock
+
             A new pangeo-metapackage version has been detected.
 
             Updated `environment.yml`s to use `${{ steps.latest_version.outputs.version }}`.
+
+            Automatically locking new conda environment, building and testing images.


### PR DESCRIPTION
new metapackages on conda-forge will now trigger a PR - https://github.com/pangeo-data/pangeo-stacks-dev/pull/40 

this small change should trigger the separate condalock workflow, which solves for the conda environment, commits package lock files, then rebuilds images with those lock files and runs tests.

cc @jhamman 