### PR TITLE
avoid force pushing to existing repo

### DIFF
--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -60,6 +60,7 @@ jobs:
             Updated `environment.yml`s to use `${{ steps.latest_version.outputs.version }}`.
 
       - name: Add Condalock Comment
+        if: steps.check_branch.outputs.exists == 'False'
         uses: peter-evans/create-or-update-comment@v1
         with:
           token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+env:
+  PR_BRANCH: upgrade-pangeo-metapackage-version
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -29,7 +32,20 @@ jobs:
           find: "pangeo-notebook=.*"
           replace: "pangeo-notebook=${{ steps.latest_version.outputs.version }}"
 
+      - name: Check if PR Already Exists
+        id: check_branch
+        run: |
+          # https://github.com/actions/checkout#fetch-all-branches
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          if git show-ref --quiet refs/remotes/origin/${PR_BRANCH}; then
+            RESULT=True
+          else
+            RESULT=False
+          fi
+          echo "::set-output name=exists::${RESULT}"
+
       - name: Create Pull Request
+        if: steps.check_branch.outputs.exists == 'False'
         id: cpr
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/WatchCondaForge.yml
+++ b/.github/workflows/WatchCondaForge.yml
@@ -53,7 +53,7 @@ jobs:
           commit-message: "Update pangeo-notebook metapackage version to ${{ steps.latest_version.outputs.version }}"
           title: "Update pangeo-notebook metapackage version to ${{ steps.latest_version.outputs.version }}"
           reviewers: "scottyhq"
-          branch: "upgrade-pangeo-metapackage-version"
+          branch: ${PR_BRANCH}
           body: |
             A new pangeo-metapackage version has been detected.
 


### PR DESCRIPTION
The current WatchCondaForge.yml force-pushes to an existing PR every hour, retriggering CI and sending emails. https://github.com/pangeo-data/pangeo-stacks-dev/pull/44 . This should avoid force pushing if an automated 'upgrade-pangeo-metapackage-version' PR already exists. cc @jhamman 